### PR TITLE
Use an exception class when raising an exception

### DIFF
--- a/src/openbmp/api/parsed/message/Base.py
+++ b/src/openbmp/api/parsed/message/Base.py
@@ -59,7 +59,7 @@ class Base(object):
         :return:  True if error, False if no errors
         """
         if not data.strip(): # If "data" is not string, throws error.
-            raise "Invalid data!", data
+            raise ValueError("Invalid data!", data)
 
         self.spec_version = float(version)
 

--- a/src/openbmp/api/parsed/message/Message.py
+++ b/src/openbmp/api/parsed/message/Message.py
@@ -23,7 +23,7 @@ class Message(object):
         """
 
         if not data.strip(): # If "data" is not string, throws error.
-            raise "Invalid data!", data
+            raise ValueError("Invalid data!", data)
 
         self.version = float()
         self.type = str()


### PR DESCRIPTION
On Python2.7 this kind of works, on Python3.{5,6} it explodes:
```
python2.7
>>> data = 'something'
>>> raise 'Invalid data!', data
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
TypeError: exceptions must be old-style classes or derived from BaseException, not str

>>> raise ValueError('Invalid data', data)
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
ValueError: ('Invalid data', 'something')
```
```
python3.6
>>> data = 'something'
>>> raise 'Invalid data!', data
  File "<stdin>", line 1
    raise 'Invalid data!', data
                         ^
SyntaxError: invalid syntax

>>> raise ValueError('Invalid data', data)
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
ValueError: ('Invalid data', 'something')
```

I might come back with some more 3.x compatibility items, but this is stopping the code even byte compiling!

Not 100% satisfied with the chosen exception, but it kind of makes sense for the purposes of the raise.